### PR TITLE
testsutils.mixins: fix pktbuf emptiness check

### DIFF
--- a/05-single-hop-route/common.py
+++ b/05-single-hop-route/common.py
@@ -30,9 +30,6 @@ def single_hop_run(source, dest, ip_src, ip_dest,
     source.reboot()
     dest.reboot()
 
-    buf_source_start = source.extract_unused()
-    buf_dest_start = dest.extract_unused()
-
     # Get useful information
     iface = source.get_first_iface()
     ip_src_ll = dest.get_ip_addr()
@@ -59,8 +56,5 @@ def single_hop_run(source, dest, ip_src, ip_dest,
 
     packet_loss = source.ping(
             count, ip_dest.split("/")[0], PAYLOAD_SIZE, DELAY)
-    buf_source_end = source.extract_unused()
-    buf_dest_end = dest.extract_unused()
 
-    return (packet_loss, buf_source_end == buf_source_start,
-            buf_dest_end == buf_dest_start)
+    return (packet_loss, source.is_empty(), dest.is_empty())

--- a/testutils/mixins.py
+++ b/testutils/mixins.py
@@ -52,3 +52,22 @@ class PktBuf:
         self.pexpect.sendline("pktbuf")
         self.pexpect.expect("unused: ([0-9xa-f]+) ")
         return self.pexpect.match.group(1)
+
+    def is_empty(self):
+        self.pexpect.sendline("pktbuf")
+        self.pexpect.expect(r"packet buffer: "
+                            r"first byte: 0x(?P<first_byte>[0-9A-Fa-f]+), "
+                            r"last byte: 0x[0-9A-Fa-f]+ "
+                            r"\(size: (?P<size>\d+)\)")
+        exp_first_byte = int(self.pexpect.match.group("first_byte"), base=16)
+        exp_size = int(self.pexpect.match.group("size"))
+        exp = self.pexpect.expect([r"~ unused: 0x(?P<first_byte>[0-9A-Fa-f]+) "
+                                   r"\(next: ((\(nil\))|0), "
+                                   r"size: (?P<size>\d+)\) ~",
+                                   pexpect.TIMEOUT])
+        if exp == 0:
+            first_byte = int(self.pexpect.match.group("first_byte"), base=16)
+            size == int(self.pexpect.match.group("size"))
+            return (exp_first_byte == first_byte) and (exp_size == size)
+        else:
+            return False

--- a/testutils/mixins.py
+++ b/testutils/mixins.py
@@ -48,11 +48,6 @@ class GNRC:
 
 
 class PktBuf:
-    def extract_unused(self):
-        self.pexpect.sendline("pktbuf")
-        self.pexpect.expect("unused: ([0-9xa-f]+) ")
-        return self.pexpect.match.group(1)
-
     def is_empty(self):
         self.pexpect.sendline("pktbuf")
         self.pexpect.expect(r"packet buffer: "


### PR DESCRIPTION
Just checking the unused pointer doesn't cut it, as it just marks unused chunk within the packet buffer (after it used chunks might come ;-)).