### PR TITLE
Handle new IPv6 ping format; handle echoing tapbr0 interface

### DIFF
--- a/testutils/mixins.py
+++ b/testutils/mixins.py
@@ -36,14 +36,13 @@ class GNRC:
                 "ping6 -c {} -i {} -s {} {} ".format(
                     count, delay, payload_size, dest_addr))
         packet_loss = None
-        for i in range(count+1):
+        while True:
             exp = self.pexpect.expect(
-                    ["bytes from", "([\\d]+) packets transmitted, ([\\d]+) "
-                     "received, ([\\d]+)% packet loss", "timeout",
+                    ["bytes from", "([\\d]+)% packet loss", "timeout", 
                      pexpect.TIMEOUT], timeout=10)
 
             if exp == 1:
-                packet_loss = int(self.pexpect.match.group(3))
+                packet_loss = int(self.pexpect.match.group(1))
                 break
             if exp == 2:
                 print("x", end="", flush=True)

--- a/testutils/mixins.py
+++ b/testutils/mixins.py
@@ -33,8 +33,8 @@ class GNRC:
 
     def ping(self, count, dest_addr, payload_size, delay):
         self.pexpect.sendline(
-                "ping6 {} {} {} {}".format(
-                    count, dest_addr, payload_size, delay))
+                "ping6 -c {} -i {} -s {} {} ".format(
+                    count, delay, payload_size, dest_addr))
         packet_loss = None
         for i in range(count+1):
             exp = self.pexpect.expect(


### PR DESCRIPTION
This is two PRs in one really, separated into two commit messages. Let me know if it needs splitting...

1. Adapt the ping command format according to the change made [here](https://github.com/RIOT-OS/RIOT/pull/9523)
2. Handle the case where the tapbr0 interface is also sending an echo back, when doing multicast testing